### PR TITLE
Generate contract and email

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "contrato",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "docxtemplater": "^3.38.0",
+    "pizzip": "^3.1.5",
+    "nodemailer": "^6.9.11"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.3"
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,7 @@
+import '../styles/globals.css';
+
+function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/pages/api/gerarContrato.js
+++ b/pages/api/gerarContrato.js
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+import Docxtemplater from 'docxtemplater';
+import PizZip from 'pizzip';
+import nodemailer from 'nodemailer';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const data = req.body;
+
+  // Carrega o documento do contrato modelo
+  const templatePath = path.join(process.cwd(), 'Contrato Vitorino.docx');
+  const content = fs.readFileSync(templatePath, 'binary');
+
+  const zip = new PizZip(content);
+  const doc = new Docxtemplater(zip, { paragraphLoop: true, linebreaks: true });
+  doc.setData(data);
+
+  try {
+    doc.render();
+  } catch (error) {
+    return res.status(500).json({ error: 'Erro ao preencher o contrato' });
+  }
+
+  const buf = doc.getZip().generate({ type: 'nodebuffer' });
+  const filename = 'ContratoPreenchido.docx';
+
+  // Configuração do Nodemailer (use variáveis de ambiente para credenciais reais)
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST || 'smtp.example.com',
+    port: process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT) : 587,
+    secure: false,
+    auth: {
+      user: process.env.SMTP_USER || 'user@example.com',
+      pass: process.env.SMTP_PASS || 'password',
+    },
+  });
+
+  try {
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || 'contrato@example.com',
+      to: process.env.TO_EMAIL || 'destino@example.com',
+      subject: 'Contrato preenchido',
+      text: 'Segue o contrato preenchido em anexo.',
+      attachments: [
+        {
+          filename,
+          content: buf,
+        },
+      ],
+    });
+  } catch (error) {
+    return res.status(500).json({ error: 'Falha ao enviar email' });
+  }
+
+  return res.status(200).json({ status: 'success' });
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+
+export default function Home() {
+  const [formData, setFormData] = useState({
+    nome: '',
+    cpf: '',
+    rg: '',
+    orgaoRg: '',
+    estadoCivil: '',
+    profissao: '',
+    endereco: '',
+    numero: '',
+    complemento: '',
+    bairro: '',
+    cidade: '',
+    cep: '',
+    quadra: '',
+    lote: '',
+    testemunha1Nome: '',
+    testemunha1Cpf: '',
+    testemunha2Nome: '',
+    testemunha2Cpf: '',
+  });
+  const [status, setStatus] = useState('');
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus('Enviando...');
+    try {
+      const res = await fetch('/api/gerarContrato', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      if (res.ok) setStatus('Enviado com sucesso!');
+      else setStatus('Falha ao enviar.');
+    } catch (err) {
+      setStatus('Erro ao enviar.');
+    }
+  };
+
+  const input = (label, name, type = 'text') => (
+    <div className="mb-4">
+      <label className="block font-medium mb-1" htmlFor={name}>{label}</label>
+      <input
+        id={name}
+        name={name}
+        type={type}
+        value={formData[name]}
+        onChange={handleChange}
+        className="w-full border rounded px-3 py-2"
+      />
+    </div>
+  );
+
+  return (
+    <div className="max-w-xl mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Contrato</h1>
+      <form onSubmit={handleSubmit} className="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+        {input('Nome completo', 'nome')}
+        {input('CPF', 'cpf')}
+        {input('RG', 'rg')}
+        {input('Órgão emissor do RG', 'orgaoRg')}
+        {input('Estado civil', 'estadoCivil')}
+        {input('Profissão', 'profissao')}
+        {input('Endereço completo (rua)', 'endereco')}
+        {input('Número', 'numero')}
+        {input('Complemento', 'complemento')}
+        {input('Bairro', 'bairro')}
+        {input('Cidade', 'cidade')}
+        {input('CEP', 'cep')}
+        {input('Quadra do terreno', 'quadra')}
+        {input('Número do lote', 'lote')}
+        {input('Nome da Testemunha 1', 'testemunha1Nome')}
+        {input('CPF da Testemunha 1', 'testemunha1Cpf')}
+        {input('Nome da Testemunha 2', 'testemunha2Nome')}
+        {input('CPF da Testemunha 2', 'testemunha2Cpf')}
+        <div className="flex items-center justify-between">
+          <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" type="submit">
+            Enviar
+          </button>
+        </div>
+        {status && <p className="mt-4 text-center">{status}</p>}
+      </form>
+    </div>
+  );
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- enhance gerarContrato API route to fill Word template and send by email
- add docxtemplater, pizzip, and nodemailer dependencies

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844beb43c248321b31b376c9ebf43c0