### PR TITLE
melhoria de retorno de erro

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ This project uses Next.js and Tailwind CSS to create a contract generation form 
 
 ## Functionality
 
-- The form in `pages/index.js` collects user data and posts it to `/api/gerarContrato`.
-- The API fills `Contrato Vitorino.docx` with the provided data using Docxtemplater, saves the result, and emails it to `meuemail@exemplo.com`.
+- The form in `pages/index.js` collects user data (including Estado civil and Profissão) and posts it to `/api/gerarContrato`.
+- The API fills `Contrato Vitorino.docx` with the provided data using Docxtemplater and then emails the result using the credentials defined in `EMAIL_USER` and `EMAIL_PASS` environment variables. O arquivo não é salvo em disco no ambiente serverless da Vercel.
+- Ensure that the Word template contains the placeholders `[EstadoCivil]` and `[Profissão]`.
 
+## Email configuration
+
+Create a `.env.local` file in the project root and define the Gmail credentials used to send the contract:
+
+```
+EMAIL_USER=seuusuario@gmail.com
+EMAIL_PASS=sua_senha_ou_app_password
+```
+
+If sua conta usa verificação em duas etapas, crie uma senha de aplicativo no painel de segurança do Google e use esse valor em `EMAIL_PASS`.

--- a/package.json
+++ b/package.json
@@ -5,31 +5,15 @@
   "scripts": {
     "dev": "next dev -H 0.0.0.0",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
     "next": "14.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react": "18.3.1",
-    "react-dom": "18.3.1",
     "docxtemplater": "^3.63.2",
     "pizzip": "^3.2.0",
-    "nodemailer": "^6.10.1"
-  },
-  "devDependencies": {
-    "autoprefixer": "^10.4.16",
-    "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.4"
-    "start": "next start",
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "dependencies": {
-    "next": "^14.2.3",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "docxtemplater": "^3.63.2",
-    "pizzip": "^3.1.5",
     "nodemailer": "^6.10.1"
   },
   "devDependencies": {

--- a/pages/api/gerarContrato.js
+++ b/pages/api/gerarContrato.js
@@ -1,10 +1,8 @@
 import { promises as fs } from 'fs';
-import fs from 'fs';
 import path from 'path';
 import Docxtemplater from 'docxtemplater';
 import PizZip from 'pizzip';
 import nodemailer from 'nodemailer';
-import { promises as fsp } from 'fs';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
@@ -14,135 +12,76 @@ export default async function handler(req, res) {
 
   const data = req.body;
 
-  // Mapeia os campos recebidos para os placeholders do documento
+  if (!process.env.EMAIL_USER || !process.env.EMAIL_PASS) {
+    console.error('EMAIL_USER or EMAIL_PASS environment variable not set');
+    return res.status(500).json({ error: 'Email configuration missing' });
+  }
+
+  // Map the received fields to the placeholders in the document
   const templateData = {
     Comprador: data.nome,
+    EstadoCivil: data.estadoCivil,
+    'Profissão': data.profissao,
     CPF: data.cpf,
     RG: data.rg,
     Emissor: data.orgaoRg,
-    'Endereço': data.endereco,
-    'Número': data.numero,
+    Endereço: data.endereco,
+    Número: data.numero,
     Complemento: data.complemento,
     Bairro: data.bairro,
     Cidade: data.cidade,
     CEP: data.cep,
     Quadra: data.quadra,
     Lote: data.lote,
-    Testemunha: `${data.testemunha1Nome} e ${data.testemunha2Nome}`,
-    'CPF Test': `${data.testemunha1Cpf} e ${data.testemunha2Cpf}`,
+    Testemunha: data.testemunha1Nome,
+    'CPF Test': data.testemunha1Cpf,
+    Testemunha2: data.testemunha2Nome,
+    'CPF Test2': data.testemunha2Cpf,
   };
 
-  // Carrega o documento do contrato modelo
+  // Load and adjust the Word document
   const templatePath = path.join(process.cwd(), 'Contrato Vitorino.docx');
   const content = await fs.readFile(templatePath, 'binary');
-
   let zip = new PizZip(content);
 
-  // Remove marcadores de correção que quebram os placeholders
+  // Fix placeholders that Word may split across multiple runs
   let xml = zip.file('word/document.xml').asText();
   xml = xml.replace(/<w:proofErr[^>]*\/>/g, '');
-  const splitTag = /\[([A-Za-z0-9 \u00C0-\u00FF]+)<\/w:t><\/w:r>\s*<w:r[^>]*>\s*(?:<w:rPr>.*?<\/w:rPr>)?\s*<w:t>\]/g;
-  xml = xml.replace(splitTag, '[$1]');
+  xml = xml.replace(
+    /<w:t>\[<\/w:t><\/w:r>\s*<w:r[^>]*>\s*(?:<w:rPr>.*?<\/w:rPr>)?\s*<w:t>([^<]*)<\/w:t><\/w:r>\s*<w:r[^>]*>\s*(?:<w:rPr>.*?<\/w:rPr>)?\s*<w:t>\]/g,
+    '[$1]'
+  );
   zip.file('word/document.xml', xml);
 
-  const parser = (tag) => ({ get: (scope) => scope[tag] });
   const doc = new Docxtemplater(zip, {
     paragraphLoop: true,
     linebreaks: true,
     delimiters: { start: '[', end: ']' },
-    parser,
+    parser: tag => ({ get: scope => scope[tag] }),
   });
+
   doc.setData(templateData);
 
   try {
     doc.render();
-  } catch (error) {
+  } catch (err) {
+    console.error('Erro ao preencher o contrato:', err);
     return res.status(500).json({ error: 'Erro ao preencher o contrato' });
   }
 
-  const buf = doc.getZip().generate({ type: 'nodebuffer' });
+  const buffer = doc.getZip().generate({ type: 'nodebuffer' });
   const filename = 'Contrato Preenchido.docx';
+  console.log('Buffer size:', buffer.length);
 
-  // Salva o contrato preenchido na raiz do projeto
-  const outputPath = path.join(process.cwd(), filename);
-  await fs.writeFile(outputPath, buf);
-
-  // Configuração do Nodemailer utilizando a conta do Gmail fornecida
   const transporter = nodemailer.createTransport({
     service: 'gmail',
     auth: {
-      user: 'contratovitorino@gmail.com',
-      pass: 'pwwf mnxs hmcs dwec',
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASS,
     },
   });
 
   try {
-    await transporter.sendMail({
-      from: 'contratovitorino@gmail.com',
-      to: 'meuemail@exemplo.com',
-  try {
-    const data = req.body;
-
-    // Mapeia os campos recebidos para os placeholders do documento
-    const templateData = {
-      Comprador: data.nome,
-      CPF: data.cpf,
-      RG: data.rg,
-      Emissor: data.orgaoRg,
-      Endereço: data.endereco,
-      Número: data.numero,
-      Complemento: data.complemento,
-      Bairro: data.bairro,
-      Cidade: data.cidade,
-      CEP: data.cep,
-      Quadra: data.quadra,
-      Lote: data.lote,
-      Testemunha: data.testemunha1Nome,
-      'CPF Test': data.testemunha1Cpf,
-      Testemunha2: data.testemunha2Nome,
-      'CPF Test2': data.testemunha2Cpf
-    };
-
-    // Carrega e ajusta o documento Word
-    const templatePath = path.join(process.cwd(), 'Contrato Vitorino.docx');
-    const content = await fsp.readFile(templatePath, 'binary');
-    let zip = new PizZip(content);
-
-    // Corrigir placeholders quebrados por marcações de correção do Word
-    let xml = zip.file('word/document.xml').asText();
-    xml = xml.replace(/<w:proofErr[^>]*\/>/g, '');
-    const splitTag = /\[([A-Za-z0-9 \u00C0-\u00FF]+)<\/w:t><\/w:r>\s*<w:r[^>]*>\s*(?:<w:rPr>.*?<\/w:rPr>)?\s*<w:t>\]/g;
-    xml = xml.replace(splitTag, '[$1]');
-    zip.file('word/document.xml', xml);
-
-    // Preparar e preencher o documento
-    const doc = new Docxtemplater(zip, {
-      paragraphLoop: true,
-      linebreaks: true,
-      delimiters: { start: '[', end: ']' },
-      parser: tag => ({ get: scope => scope[tag] }),
-    });
-
-    doc.setData(templateData);
-
-    try {
-      doc.render();
-    } catch (err) {
-      console.error('Erro ao preencher o contrato:', err);
-      return res.status(500).json({ error: 'Erro ao preencher o contrato' });
-    }
-
-    const buffer = doc.getZip().generate({ type: 'nodebuffer' });
-
-    // Configuração segura do e-mail via variáveis de ambiente
-    const transporter = nodemailer.createTransport({
-      service: 'gmail',
-      auth: {
-        user: process.env.EMAIL_USER,
-        pass: process.env.EMAIL_PASS,
-      },
-    });
-
     await transporter.sendMail({
       from: process.env.EMAIL_USER,
       to: 'rba1807@gmail.com',
@@ -151,24 +90,17 @@ export default async function handler(req, res) {
       attachments: [
         {
           filename,
-          content: buf,
-        },
-      ],
-    });
-  } catch (error) {
-    return res.status(500).json({ error: 'Falha ao enviar email' });
-  }
-
-  return res.status(200).json({ status: 'success' });
-          filename: 'Contrato Preenchido.docx',
           content: buffer,
         },
       ],
     });
-
-    return res.status(200).json({ status: 'success' });
   } catch (err) {
-    console.error('Erro inesperado:', err);
-    return res.status(500).json({ error: 'Erro inesperado' });
+    console.error('Falha ao enviar email:', err);
+    return res.status(500).json({
+      error: 'Falha ao enviar email',
+      details: err.message,
+    });
   }
+
+  return res.status(200).json({ status: 'success' });
 }


### PR DESCRIPTION
## Summary
- incluir mensagem detalhada ao falhar o envio de e-mail
- corrigir placeholders divididos no documento Word para `[EstadoCivil]` e `[Profissão]`
- evitar a gravação do contrato em disco e registrar o tamanho do buffer

## Testing
- `npm test` *(fails: command not found)*
- `npm run build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845899022808321a85f0d276f3e2c6f